### PR TITLE
Add support for latest grok models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ai list all png files in the current directory
 
 - Choose a specific LLM model:
   ```bash
-  ai --model <model-name> (default llama3-8b-8192)
+  ai --model <model-name> (default llama-3.1-8b-instant)
   ```
 
 - Set the history size for context-aware suggestions:
@@ -60,19 +60,25 @@ ai list all png files in the current directory
 
 ## Supported Models
 
-- llama3-8b-8192
-- gemma2-9b-it
-- gemma-7b-it
-- llama3-70b-8192
-- llama-3.1-70b-versatile
-- llama-3.1-8b-instant
-- llava-v1.5-7b-4096-preview
-- mixtral-8x7b-32768
+### Current Production Models
 
-### Latest Grok Models from xAI
+- **llama-3.3-70b-versatile** - Latest Llama 3.3 model with excellent reasoning capabilities
+- **llama-3.1-8b-instant** - Fast and efficient model, great for quick command generation
+- **gemma2-9b-it** - Google's Gemma 2 model optimized for instruction following
 
-- grok-3-beta (most advanced, superior reasoning capabilities)
-- grok-3-mini-beta (lightweight, faster responses)
-- grok-3-mini-fast-beta (optimized for speed)
-- grok-beta (comparable to Grok 2 with improved efficiency)
-- grok-vision-beta (includes vision capabilities)
+### Latest Advanced Models
+
+- **meta-llama/llama-4-scout-17b-16e-instruct** - Llama 4 Scout for complex reasoning tasks
+- **meta-llama/llama-4-maverick-17b-128e-instruct** - Llama 4 Maverick for multilingual tasks
+- **deepseek-r1-distill-llama-70b** - Advanced reasoning model for complex problem-solving
+- **deepseek-r1-distill-qwen-32b** - Efficient reasoning model with strong coding capabilities
+- **qwen-2.5-32b** - Qwen 2.5 with improved coding and instruction following
+- **qwen-qwq-32b** - Latest Qwen reasoning model
+- **mistral-saba-24b** - Updated Mistral model
+
+### Legacy Models (Being Deprecated)
+
+- **llama3-70b-8192** - Will be deprecated on August 30, 2025 (use llama-3.3-70b-versatile instead)
+- **llama3-8b-8192** - Will be deprecated on August 30, 2025 (use llama-3.1-8b-instant instead)
+
+**Note:** Vision models have been removed as they're not suitable for command-line terminal operations.

--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ ai list all png files in the current directory
 - llama-3.1-8b-instant
 - llava-v1.5-7b-4096-preview
 - mixtral-8x7b-32768
+
+### Latest Grok Models from xAI
+
+- grok-3-beta (most advanced, superior reasoning capabilities)
+- grok-3-mini-beta (lightweight, faster responses)
+- grok-3-mini-fast-beta (optimized for speed)
+- grok-beta (comparable to Grok 2 with improved efficiency)
+- grok-vision-beta (includes vision capabilities)

--- a/README.md
+++ b/README.md
@@ -80,5 +80,3 @@ ai list all png files in the current directory
 
 - **llama3-70b-8192** - Will be deprecated on August 30, 2025 (use llama-3.3-70b-versatile instead)
 - **llama3-8b-8192** - Will be deprecated on August 30, 2025 (use llama-3.1-8b-instant instead)
-
-**Note:** Vision models have been removed as they're not suitable for command-line terminal operations.

--- a/groq_terminal_ai/cli.py
+++ b/groq_terminal_ai/cli.py
@@ -30,7 +30,7 @@ def main():
         print("Please set the GROQ_API_KEY with 'ai --groq-api-key <key>'.")
         sys.exit(1)
 
-    model_choice = args.model or config.get('MODEL') or ModelEnum.LLAMA3_8B_8192.value
+    model_choice = args.model or config.get('MODEL') or ModelEnum.LLAMA3_1_8B_INSTANT.value
     history_size = args.history_size if args.history_size is not None else load_history_size()
     use_history = args.use_history if args.use_history is not None else load_use_history()
 

--- a/groq_terminal_ai/models.py
+++ b/groq_terminal_ai/models.py
@@ -1,18 +1,28 @@
 from enum import Enum
 
 class ModelEnum(Enum):
-    LLAMA3_8B_8192 = "llama3-8b-8192"
-    GEMMA2_9B_IT = "gemma2-9b-it"
-    GEMMA_7B_IT = "gemma-7b-it"
-    LLAMA3_70B_8192 = "llama3-70b-8192"
-    LLAMA3_1_70B_VERSATILE = "llama-3.1-70b-versatile"
+    # Updated Llama models (replacing deprecated ones)
+    LLAMA3_3_70B_VERSATILE = "llama-3.3-70b-versatile"
     LLAMA3_1_8B_INSTANT = "llama-3.1-8b-instant"
-    LLAVA_V1_5_7B_4096_PREVIEW = "llava-v1.5-7b-4096-preview"
-    MIXTRAL_8X7B_32768 = "mixtral-8x7b-32768"
     
-    # Latest Grok models from xAI
-    GROK_3_BETA = "grok-3-beta"
-    GROK_3_MINI_BETA = "grok-3-mini-beta"
-    GROK_3_MINI_FAST_BETA = "grok-3-mini-fast-beta"
-    GROK_BETA = "grok-beta"
-    GROK_VISION_BETA = "grok-vision-beta"
+    # Latest Llama 4 models (excellent for reasoning and code generation)
+    LLAMA4_SCOUT = "meta-llama/llama-4-scout-17b-16e-instruct"
+    LLAMA4_MAVERICK = "meta-llama/llama-4-maverick-17b-128e-instruct"
+    
+    # Current Gemma model (7B deprecated, using 9B)
+    GEMMA2_9B_IT = "gemma2-9b-it"
+    
+    # DeepSeek reasoning models (great for complex problem solving)
+    DEEPSEEK_R1_DISTILL_LLAMA_70B = "deepseek-r1-distill-llama-70b"
+    DEEPSEEK_R1_DISTILL_QWEN_32B = "deepseek-r1-distill-qwen-32b"
+    
+    # Qwen models (excellent for coding and instruction following)
+    QWEN_2_5_32B = "qwen-2.5-32b"
+    QWEN_QWQ_32B = "qwen-qwq-32b"
+    
+    # Updated Mistral model
+    MISTRAL_SABA_24B = "mistral-saba-24b"
+    
+    # Keep legacy models for backward compatibility until they're fully deprecated
+    LLAMA3_70B_8192 = "llama3-70b-8192"  # Deprecated Aug 30, 2025
+    LLAMA3_8B_8192 = "llama3-8b-8192"    # Deprecated Aug 30, 2025

--- a/groq_terminal_ai/models.py
+++ b/groq_terminal_ai/models.py
@@ -9,3 +9,10 @@ class ModelEnum(Enum):
     LLAMA3_1_8B_INSTANT = "llama-3.1-8b-instant"
     LLAVA_V1_5_7B_4096_PREVIEW = "llava-v1.5-7b-4096-preview"
     MIXTRAL_8X7B_32768 = "mixtral-8x7b-32768"
+    
+    # Latest Grok models from xAI
+    GROK_3_BETA = "grok-3-beta"
+    GROK_3_MINI_BETA = "grok-3-mini-beta"
+    GROK_3_MINI_FAST_BETA = "grok-3-mini-fast-beta"
+    GROK_BETA = "grok-beta"
+    GROK_VISION_BETA = "grok-vision-beta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "groq-terminal-ai"
-version = "1.0.1"
+version = "1.1.0"
 readme = "README.md"
 description = "groq-terminal-ai is a command line tool that uses AI to generate terminal commands"
 dependencies = [


### PR DESCRIPTION
Update supported models to align with the latest Groq platform offerings and remove unsuitable vision models.

The initial implementation mistakenly added xAI's Grok models and a vision model. This PR corrects that by adding the latest and most suitable text-based models available on the Groq platform, removing vision models as they are not relevant for a CLI command generation tool, and updating the default model.